### PR TITLE
fix: Spawning typescript-language-server error

### DIFF
--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -1,7 +1,7 @@
 local options = {
-  ensure_installed = { "lua-language-server" }, -- not an option from mason.nvim
+  ensure_installed = { "lua-language-server", "typescript-language-server" }, -- not an option from mason.nvim
 
-  PATH = "skip",
+  PATH = "prepend",
 
   ui = {
     icons = {


### PR DESCRIPTION
fix error:
```Spawning language server with cmd: `typescript-language-server` failed. The language server is either not installed, missing from PATH, or not executable.```